### PR TITLE
Feat: add evm loader

### DIFF
--- a/data/languages/evm.opinion
+++ b/data/languages/evm.opinion
@@ -1,12 +1,5 @@
 <opinions>
-<!-- Example of importer opinions - commented-out to prevent use by Ghidra -->
-<!-- The primary and secondary constraint values must be specifide as a decimal string -->
-<!--
-    <constraint loader="Executable and Linking Format (ELF)" compilerSpecID="default">
-    		<constraint primary="40"   secondary="123"  processor="Skel"  size="16" variant="default" />
+    <constraint loader="EVMLoader" compilerSpecID="default">
+        <constraint primary="1" processor="EVM" size="256" />
     </constraint>
-    <constraint loader="MS Common Object File Format (COFF)" compilerSpecID="default">
-        <constraint primary="61"                    processor="Skel"  size="16" variant="default" />
-    </constraint>
--->
 </opinions>

--- a/src/main/java/ghidrevm/GhidrevmLoader.java
+++ b/src/main/java/ghidrevm/GhidrevmLoader.java
@@ -16,22 +16,32 @@
 package ghidrevm;
 
 import java.io.IOException;
+
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import ghidra.app.util.Option;
 import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.importer.MessageLog;
-import ghidra.app.util.opinion.AbstractProgramWrapperLoader;
+//import ghidra.app.util.opinion.AbstractProgramWrapperLoader;
+import ghidra.app.util.opinion.AbstractLibrarySupportLoader;
 import ghidra.app.util.opinion.LoadSpec;
 import ghidra.framework.model.DomainObject;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.lang.LanguageCompilerSpecPair;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
 
 /**
  * TODO: Provide class-level documentation that describes what this loader does.
  */
-public class GhidrevmLoader extends AbstractProgramWrapperLoader {
+public class GhidrevmLoader extends AbstractLibrarySupportLoader {
+	boolean fEVM = false; 	// EVM Hexadecimal
+	boolean fEVM_H = false; // EVM Byte Code 
 
 	@Override
 	public String getName() {
@@ -39,13 +49,21 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 		// TODO: Name the loader.  This name must match the name of the loader in the .opinion 
 		// files.
 
-		return "My loader";
+		return "EVMLoader";
 	}
 
 	@Override
 	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
 		List<LoadSpec> loadSpecs = new ArrayList<>();
-
+		this.fEVM = provider.getName().endsWith(".evm");
+		this.fEVM_H = provider.getName().endsWith(".evm_h");
+		
+		if(this.fEVM || this.fEVM_H) {
+			LanguageCompilerSpecPair compilerSpec = new LanguageCompilerSpecPair("evm:256:default", "default");
+			LoadSpec loadspec = new LoadSpec(this, 0, compilerSpec, true);
+			loadSpecs.add(loadspec);
+		}
+		
 		// TODO: Examine the bytes in 'provider' to determine if this loader can load it.  If it 
 		// can load it, return the appropriate load specifications.
 
@@ -58,6 +76,53 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 			throws CancelledException, IOException {
 
 		// TODO: Load the bytes from 'provider' into the 'program'.
+		FlatProgramAPI flatAPI = new FlatProgramAPI(program);
+		
+		try {
+			if(this.fEVM) {
+				monitor.setMessage("EVM Code: Loading Starts");
+				Address addr = flatAPI.toAddr(0x0);
+				MemoryBlock block = flatAPI.createMemoryBlock("ram", addr, provider.readBytes(0, provider.length()), false);
+				
+				block.setRead(true);
+				block.setWrite(true);
+				block.setExecute(true);
+				
+				flatAPI.addEntryPoint(addr);
+				monitor.setMessage("EVM Code: Loading Ends");
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new IOException("EVM Code: Loading Fails");
+		}
+		
+		try {
+			if(this.fEVM_H) {
+				monitor.setMessage("EVM Code: Loading Starts");
+				CharSequence seq = new String(provider.readBytes(0, provider.length()), "UTF-8");
+				Pattern p = Pattern.compile("[0-9a-fA-F]{2}");
+				Matcher m = p.matcher(seq);				
+				int count = m.groupCount();
+				
+				byte[] hex_code = new byte[count];
+				int i = 0;
+				while(m.find()) {
+					String digits = m.group();
+					hex_code[i++] = (byte)Integer.parseInt(digits, 16);
+				}
+				Address addr = flatAPI.toAddr(0x0);
+				MemoryBlock block = flatAPI.createMemoryBlock("ram", addr, hex_code, false);
+				
+				block.setRead(true);
+				block.setWrite(true);
+				block.setExecute(true);
+				
+				flatAPI.addEntryPoint(addr);
+				monitor.setMessage("EVM Code: Loading Ends");
+			}
+		} catch(Exception e) {
+			throw new IOException("EVM Code: Loading Ends");
+		}
 	}
 
 	@Override
@@ -67,7 +132,7 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 			super.getDefaultOptions(provider, loadSpec, domainObject, isLoadIntoProgram);
 
 		// TODO: If this loader has custom options, add them to 'list'
-		list.add(new Option("Option name goes here", "Default option value goes here"));
+		// list.add(new Option("Option name goes here", "Default option value goes here"));
 
 		return list;
 	}


### PR DESCRIPTION
# Introduction

We can download EVM bytecode from the EVM-compatible blockchain system. However, we currently cannot directly analyze the bytecode through Ghidra; we must first convert it from bytecode to hexadecimal format.

In this PR, we add a new loader to support bytecode format for further analysis.

# Note
1. The return value of the `getName` function in `GhidrevmLoader` should be equivalent to the `loader` value in `evm.opinion`.
2. The extension should implement `getName`, `findSupportedLoadSpecs`, and `load` for Ghidra to identify the loader.

# Verification
TBD

# Problem

The new loader feature does not display. I am not sure whether it is the environment configuration issue or the error in implementation.

<img width="805" alt="Screenshot 2024-06-18 at 3 21 26 PM" src="https://github.com/syjcnss/Ghidrevm/assets/72684086/4c3c489d-f198-486a-8955-03776d712878">
