### PR TITLE
Feat: add hex loader

### DIFF
--- a/data/languages/evm.opinion
+++ b/data/languages/evm.opinion
@@ -1,12 +1,5 @@
 <opinions>
-<!-- Example of importer opinions - commented-out to prevent use by Ghidra -->
-<!-- The primary and secondary constraint values must be specifide as a decimal string -->
-<!--
-    <constraint loader="Executable and Linking Format (ELF)" compilerSpecID="default">
-    		<constraint primary="40"   secondary="123"  processor="Skel"  size="16" variant="default" />
+	<constraint loader="EVM loader" compilerSpecID="default">
+        <constraint	processor="EVM" endian="big" size="256" />
     </constraint>
-    <constraint loader="MS Common Object File Format (COFF)" compilerSpecID="default">
-        <constraint primary="61"                    processor="Skel"  size="16" variant="default" />
-    </constraint>
--->
 </opinions>

--- a/src/main/java/ghidrevm/GhidrevmLoader.java
+++ b/src/main/java/ghidrevm/GhidrevmLoader.java
@@ -40,6 +40,7 @@ import ghidra.program.model.mem.MemoryBlock;
 public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 	
 	boolean isHexCode = false;
+	Integer contractSizeLimit = 24576;
 
 	@Override
 	public String getName() {
@@ -53,11 +54,13 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 		byte[] data = provider.readBytes(0, provider.length());
 		String seq = new String(data, "UTF-8");
 		this.isHexCode = seq.matches("^[0-9A-Fa-f]+$");
-
-		LanguageCompilerSpecPair compilerSpec = new LanguageCompilerSpecPair("evm:256:default", "default");
-		LoadSpec loadSpec = new LoadSpec(this, 0, compilerSpec, true);
-		loadSpecs.add(loadSpec);
 		
+		if((!this.isHexCode && provider.length() <= contractSizeLimit * 8) || (this.isHexCode && provider.length() <= contractSizeLimit * 2)) {
+			LanguageCompilerSpecPair compilerSpec = new LanguageCompilerSpecPair("evm:256:default", "default");
+			LoadSpec loadSpec = new LoadSpec(this, 0, compilerSpec, true);
+			loadSpecs.add(loadSpec);
+		}
+
 		return loadSpecs;
 	}
 

--- a/src/main/java/ghidrevm/GhidrevmLoader.java
+++ b/src/main/java/ghidrevm/GhidrevmLoader.java
@@ -17,6 +17,8 @@ package ghidrevm;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import ghidra.app.util.Option;
 import ghidra.app.util.bin.ByteProvider;
@@ -25,39 +27,95 @@ import ghidra.app.util.opinion.AbstractProgramWrapperLoader;
 import ghidra.app.util.opinion.LoadSpec;
 import ghidra.framework.model.DomainObject;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.lang.LanguageCompilerSpecPair;
+import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.mem.MemoryBlock;
 
 /**
  * TODO: Provide class-level documentation that describes what this loader does.
  */
 public class GhidrevmLoader extends AbstractProgramWrapperLoader {
+	
+	boolean isByteCode = false;
+	boolean isHexCode = false;
 
 	@Override
 	public String getName() {
-
-		// TODO: Name the loader.  This name must match the name of the loader in the .opinion 
-		// files.
-
-		return "My loader";
+		return "EVM loader";
 	}
 
 	@Override
 	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
 		List<LoadSpec> loadSpecs = new ArrayList<>();
-
-		// TODO: Examine the bytes in 'provider' to determine if this loader can load it.  If it 
-		// can load it, return the appropriate load specifications.
-
+		
+		byte[] data = provider.readBytes(0, provider.length());
+		String seq = new String(data, "UTF-8");
+		
+		this.isByteCode = seq.matches("^[01]+$");
+		this.isHexCode = seq.matches("^[0-9A-Fa-f]+$");
+		
+		if(this.isByteCode || this.isHexCode) {
+			LanguageCompilerSpecPair compilerSpec = new LanguageCompilerSpecPair("evm:256:default", "default");
+			LoadSpec loadSpec = new LoadSpec(this, 0, compilerSpec, true);
+			loadSpecs.add(loadSpec);
+		} else {
+			System.out.println(seq);
+		}
 		return loadSpecs;
 	}
 
 	@Override
 	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options,
-			Program program, TaskMonitor monitor, MessageLog log)
-			throws CancelledException, IOException {
+		Program program, TaskMonitor monitor, MessageLog log)
+		throws CancelledException, IOException {
+		
+			monitor.setMessage("EVM: Start Loading...");
+			FlatProgramAPI flatAPI = new FlatProgramAPI(program);
+		
+			Address addr = flatAPI.toAddr(0x0);
+			byte[] data = provider.readBytes(0, provider.length());
+			CharSequence seq = new String(data, "UTF-8");
+			
+			try {
+				if(this.isByteCode) {
+					MemoryBlock block = flatAPI.createMemoryBlock("code", addr, data, false);
 
-		// TODO: Load the bytes from 'provider' into the 'program'.
+					block.setRead(true);
+					block.setWrite(false);
+					block.setExecute(true);
+					
+					flatAPI.addEntryPoint(addr);
+				} else if(this.isHexCode) {
+					Pattern p = Pattern.compile("[0-9a-fA-F]{2}");
+					Matcher m = p.matcher(seq);
+
+					int count = (int) m.results().count() + 1;
+					m.reset();
+
+					byte[] byte_code = new byte[count];
+
+					int i = 0;
+					while(m.find()) {
+						String hex_digit = m.group();
+						byte_code[i++] = (byte)Integer.parseInt(hex_digit, 16);
+					}
+					MemoryBlock block = flatAPI.createMemoryBlock("code", addr, byte_code, false);
+
+					block.setRead(true);
+					block.setWrite(false);
+					block.setExecute(true);
+
+					flatAPI.addEntryPoint(addr);
+				}
+			} catch(Exception e) {
+				e.printStackTrace();
+				throw new IOException("EVM Code: Fail Loading...");
+			}
+
+			monitor.setMessage("EVM Code: End Loading...");
 	}
 
 	@Override
@@ -66,17 +124,11 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 		List<Option> list =
 			super.getDefaultOptions(provider, loadSpec, domainObject, isLoadIntoProgram);
 
-		// TODO: If this loader has custom options, add them to 'list'
-		list.add(new Option("Option name goes here", "Default option value goes here"));
-
 		return list;
 	}
 
 	@Override
 	public String validateOptions(ByteProvider provider, LoadSpec loadSpec, List<Option> options, Program program) {
-
-		// TODO: If this loader has custom options, validate them here.  Not all options require
-		// validation.
 
 		return super.validateOptions(provider, loadSpec, options, program);
 	}

--- a/src/main/java/ghidrevm/GhidrevmLoader.java
+++ b/src/main/java/ghidrevm/GhidrevmLoader.java
@@ -52,7 +52,7 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 		List<LoadSpec> loadSpecs = new ArrayList<>();
 		
 		byte[] data = provider.readBytes(0, provider.length());
-		String seq = new String(data, "UTF-8");
+		String seq = new String(data, "UTF-8").strip();
 		this.isHexCode = seq.matches("^[0-9A-Fa-f]+$");
 
 		if((!this.isHexCode && provider.length() <= contractSizeLimit) || (this.isHexCode && provider.length() <= contractSizeLimit * 2)) {
@@ -82,7 +82,7 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 				Pattern p = Pattern.compile("[0-9a-fA-F]{2}");
 				Matcher m = p.matcher(seq);
 
-				int count = (int) m.results().count() + 1;
+				int count = (int) m.results().count();
 				m.reset();
 
 				byte[] byte_code = new byte[count];


### PR DESCRIPTION
# Summary
The original Ghidra extension does not support the hexadecimal file format, this PR add the functionality by examining the codebase.

# Introduction
The original Ghidrevm only support the raw binary file format, users should convert the raw binary file into hexadecimal format for further analysis. In this PR, the new `EVM loader` will dynamically analyze the file content to determine which of the file type it is and load the program with corresponding loader.

Users can download the deployed code on block explorer and start analyzing using Ghidrevm without any format conversion.


# Verification

I take Uniswap V2 Router on the Ethereum mainnet as our test case. 

Address: [0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D](https://etherscan.io/address/0x7a250d5630b4cf539739df2c5dacb4c659f2488d#code)

1. Download the deployed code in `uni.evm_h` file.
2. Create another file named `uni.evm`.
3. Run `cat uni.evm_h | xxd -p -r > uni.evm`.
4. Run the project as Ghidra.
5. Import `uni.evm_h` by `EVM loader`, and select the `EVM` language.
6. Import `uni.evm` by `EVM loader`, and select the `EVM` language.
7. Analyze these two files with `EVM Disassembler` and `EVM Function Analyzer`.
8. Compare the result.

The analysis result of `uni.evm_h`: 
<img width="1256" alt="Screenshot 2024-06-24 at 5 07 45 PM" src="https://github.com/syjcnss/Ghidrevm/assets/72684086/79ef4c86-210b-40d9-87e6-0fe8dbfa7d90">

The analysis result of `uni.evm`:
<img width="1256" alt="Screenshot 2024-06-24 at 5 08 43 PM" src="https://github.com/syjcnss/Ghidrevm/assets/72684086/b80abf5a-2678-4a78-9866-c35b99fed46c">


