### PR TITLE
Feat: decode metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/*
 .classpath
 .antProperties.xml
 bin/ghidrevm
+lib/

--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,15 @@ repositories {
 	// dropped into the lib/ directory.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html for more info.
 	// Ex: mavenCentral()
+	mavenCentral()
 }
 
 dependencies {
 	// Any external dependencies added here will automatically be copied to the lib/ directory when
 	// this extension is built.	
+	// https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformats-cbor
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.17.2'
+	implementation 'org.bitcoinj:bitcoinj-core:0.12'
 }
 
 // Exclude additional files from the built extension

--- a/src/main/java/ghidrevm/GhidrevmLoader.java
+++ b/src/main/java/ghidrevm/GhidrevmLoader.java
@@ -41,7 +41,7 @@ import ghidra.framework.options.Options;
  * TODO: Provide class-level documentation that describes what this loader does.
  */
 public class GhidrevmLoader extends AbstractProgramWrapperLoader {
-	
+
 	boolean isHexCode = false;
 	Integer contractSizeLimit = 24576 * 2;
 
@@ -53,12 +53,13 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 	@Override
 	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
 		List<LoadSpec> loadSpecs = new ArrayList<>();
-		
+
 		byte[] data = provider.readBytes(0, provider.length());
 		String seq = new String(data, "UTF-8").strip();
 		this.isHexCode = seq.matches("^[0-9A-Fa-f]+$");
 
-		if((!this.isHexCode && provider.length() <= contractSizeLimit) || (this.isHexCode && provider.length() <= contractSizeLimit * 2)) {
+		if ((!this.isHexCode && provider.length() <= contractSizeLimit)
+				|| (this.isHexCode && provider.length() <= contractSizeLimit * 2)) {
 			LanguageCompilerSpecPair compilerSpec = new LanguageCompilerSpecPair("evm:256:default", "default");
 			LoadSpec loadSpec = new LoadSpec(this, 0, compilerSpec, true);
 			loadSpecs.add(loadSpec);
@@ -69,82 +70,81 @@ public class GhidrevmLoader extends AbstractProgramWrapperLoader {
 
 	@Override
 	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options,
-		Program program, TaskMonitor monitor, MessageLog log)
-		throws CancelledException, IOException {
-		
-			monitor.setMessage("EVM: Start Loading...");
-			FlatProgramAPI flatAPI = new FlatProgramAPI(program);
-		
-			Address addr = flatAPI.toAddr(0x0);
-			byte[] data = provider.readBytes(0, provider.length());
-			CharSequence seq = new String(data, "UTF-8");
+			Program program, TaskMonitor monitor, MessageLog log)
+			throws CancelledException, IOException {
 
-			MemoryBlock block;
+		monitor.setMessage("EVM: Start Loading...");
+		FlatProgramAPI flatAPI = new FlatProgramAPI(program);
 
-			if(this.isHexCode) {
-				Pattern p = Pattern.compile("[0-9a-fA-F]{2}");
-				Matcher m = p.matcher(seq);
+		Address addr = flatAPI.toAddr(0x0);
+		byte[] data = provider.readBytes(0, provider.length());
+		CharSequence seq = new String(data, "UTF-8");
 
-				int count = (int) m.results().count();
-				m.reset();
+		MemoryBlock block;
 
-				byte[] byte_code = new byte[count];
+		if (this.isHexCode) {
+			Pattern p = Pattern.compile("[0-9a-fA-F]{2}");
+			Matcher m = p.matcher(seq);
 
-				int i = 0;
-				while(m.find()) {
-					String hex_digit = m.group();
-					byte_code[i++] = (byte) Integer.parseInt(hex_digit, 16);
-				}
-				data = byte_code;
+			int count = (int) m.results().count();
+			m.reset();
+
+			byte[] byte_code = new byte[count];
+
+			int i = 0;
+			while (m.find()) {
+				String hex_digit = m.group();
+				byte_code[i++] = (byte) Integer.parseInt(hex_digit, 16);
 			}
+			data = byte_code;
+		}
 
-			try {
-				block = flatAPI.createMemoryBlock("code", addr, data, false);
+		try {
+			block = flatAPI.createMemoryBlock("code", addr, data, false);
 
-				block.setRead(true);
-				block.setWrite(false);
-				block.setExecute(true);
+			block.setRead(true);
+			block.setWrite(false);
+			block.setExecute(true);
 
-				flatAPI.addEntryPoint(addr);
-			} catch(Exception e) {
-				e.printStackTrace();
-				throw new IOException("EVM Code: Fail Loading...");
-			}
+			flatAPI.addEntryPoint(addr);
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new IOException("EVM Code: Fail Loading...");
+		}
 
-			try {
-				// Metadata Decode
-				MetadataObj metadata = new MetadataObj(data);
-				metadata.decodeMetadata();
+		try {
+			// Metadata Decode
+			MetadataObj metadata = new MetadataObj(data);
+			metadata.decodeMetadata();
 
-				// Metadata Configuration
-				Options props = program.getOptions(program.PROGRAM_INFO);
+			// Metadata Configuration
+			Options props = program.getOptions(program.PROGRAM_INFO);
 
-				program.setCompiler(metadata.getSolcVersion());
-				props.setString("Solc Version", metadata.getSolcVersion());
-				props.setString("IPFS Hash", metadata.getIpfs());
-				props.setString("bzzr0", metadata.getBzzr0());
-				props.setString("bzzr1", metadata.getBzzr1());
+			program.setCompiler(metadata.getSolcVersion());
+			props.setString("Solc Version", metadata.getSolcVersion());
+			props.setString("IPFS Hash", metadata.getIpfs());
+			props.setString("bzzr0", metadata.getBzzr0());
+			props.setString("bzzr1", metadata.getBzzr1());
 
-				new CborDecoder(flatAPI, metadata.getStartIndex(), metadata.getMetadataByteCode());
-				
-				Address a = flatAPI.toAddr(data.length-2);
-				flatAPI.createWord(a);
-				flatAPI.setEOLComment(a, "Metadata Length");
-				
-			} catch(Exception e) {
-				e.printStackTrace();
-				throw new IOException("EVM Code: Metadata Decode Fails...");
-			}
+			new CborDecoder(flatAPI, metadata.getStartIndex(), metadata.getMetadataByteCode());
 
-			// End Loading
-			monitor.setMessage("EVM Code: End Loading...");
+			Address a = flatAPI.toAddr(data.length - 2);
+			flatAPI.createWord(a);
+			flatAPI.setEOLComment(a, "Metadata Length");
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new IOException("EVM Code: Metadata Decode Fails...");
+		}
+
+		// End Loading
+		monitor.setMessage("EVM Code: End Loading...");
 	}
 
 	@Override
 	public List<Option> getDefaultOptions(ByteProvider provider, LoadSpec loadSpec,
 			DomainObject domainObject, boolean isLoadIntoProgram) {
-		List<Option> list =
-			super.getDefaultOptions(provider, loadSpec, domainObject, isLoadIntoProgram);
+		List<Option> list = super.getDefaultOptions(provider, loadSpec, domainObject, isLoadIntoProgram);
 
 		return list;
 	}

--- a/src/main/java/ghidrevm/evm/CborDecoder.java
+++ b/src/main/java/ghidrevm/evm/CborDecoder.java
@@ -28,6 +28,137 @@ public class CborDecoder {
     private FlatProgramAPI api;
     private int index;
 
+    public CborDecoder(FlatProgramAPI api, int index, byte[] data) throws IOException {
+        // Environment Configuration
+        this.api = api;
+        this.index = index;
+        Address addr = api.toAddr(index);
+        api.setPlateComment(addr, "Smart Contract Metadata");
+
+        // Metadata Decoding
+        ByteArrayInputStream input = new ByteArrayInputStream(data);
+        while (input.available() > 0) {
+            System.out.println(decode(input));
+        }
+    }
+
+    public Object decode(InputStream input) throws IOException {
+        int length = 0;
+        String comment = "";
+        int initialByte = input.read();
+
+        if (initialByte == -1) {
+            throw new IOException("Unexpected end of input");
+        }
+
+        // unsigned integer 0x00..0x17 (0..23)
+        if (initialByte <= 0x17) {
+            comment = "Num(" + initialByte + ")";
+            generateComment(comment, 1, false);
+            return initialByte;
+        }
+
+        if (initialByte >= 0x18 && initialByte <= 0x1b) {
+            length = (int) Math.pow(2, initialByte - 0x18);
+            comment = "Read " + length + " Elements";
+            generateComment(comment, 1, false);
+            return (long) readValue(input, length);
+        }
+
+        // negative integer -1-0x00..-1-0x17 (-1..-24)
+        if (initialByte >= 0x20 && initialByte <= 0x37) {
+            comment = "Num(" + (-1 - (initialByte - 0x20)) + ")";
+            generateComment(comment, 1, false);
+            return -1 - (initialByte - 0x20);
+        }
+
+        if (initialByte >= 0x38 && initialByte <= 0x3b) {
+            length = (int) Math.pow(2, initialByte - 0x38);
+            comment = "Read " + length + " Elements";
+            generateComment(comment, 1, false);
+            return -1 - readValue(input, length);
+        }
+
+        // byte string (0x00..0x17 bytes follow)
+        if (initialByte >= 0x40 && initialByte <= 0x57) {
+            comment = "Bytes(" + (initialByte - 0x40) + ")";
+            generateComment(comment, 1, false);
+            return readByte(input, initialByte - 0x40, false);
+        }
+
+        if (initialByte >= 0x58 && initialByte <= 0x5b) {
+            length = (int) Math.pow(2, initialByte - 0x58);
+            comment = "Read " + (initialByte - 0x57) + " Elements";
+            generateComment(comment, 1, false);
+            return readByte(input, readValue(input, length), false);
+        }
+
+        // UTF-8 string (0x00..0x17 bytes follow)
+        if (initialByte >= 0x60 && initialByte <= 0x77) {
+            length = initialByte - 0x60;
+            comment = "Text(" + length + ")";
+            generateComment(comment, 1, false);
+            return readByte(input, length, true);
+        }
+
+        if (initialByte <= 0x78 && initialByte >= 0x7b) {
+            length = (int) Math.pow(2, initialByte - 0x78);
+            comment = "Read " + length + " Elements";
+            generateComment(comment, 1, false);
+            return readByte(input, length, true);
+        }
+
+        // array (0x00..0x17 data items follow)
+        if (initialByte >= 0x80 && initialByte <= 0x97) {
+            comment = "Array(" + (initialByte - 0x80) + ")";
+            generateComment(comment, 1, false);
+            return readArray(input, initialByte - 0x80);
+        }
+
+        if (initialByte >= 0x98 && initialByte <= 0x9b) {
+            length = (int) Math.pow(2, initialByte - 0x98);
+            comment = "Read " + length + " Elements";
+            return readArray(input, readValue(input, length));
+        }
+
+        // map (0x00..0x17 pairs of data items follow)
+        if (initialByte >= 0xa0 && initialByte <= 0xb7) {
+            comment = "Map(" + (initialByte - 0xa0) + ")";
+            generateComment(comment, 1, false);
+            return readMap(input, initialByte - 0xa0);
+        }
+
+        if (initialByte >= 0xb8 && initialByte <= 0xbb) {
+            length = (int) Math.pow(2, initialByte - 0x78);
+            comment = "Read " + length + " Elements";
+            generateComment(comment, 1, false);
+            return readMap(input, length);
+        }
+
+        switch (initialByte) {
+            case 0xf4:
+                comment = "false";
+                break;
+            case 0xf5:
+                comment = "true";
+                break;
+            case 0xf6:
+                comment = "null";
+                break;
+            case 0xf7:
+                comment = "undefined";
+                break;
+            case 0xff:
+                comment = "break";
+                break;
+            default:
+                throw new IOException("Unsupported Inital Byte: " + initialByte);
+        }
+
+        generateComment(comment, 1, false);
+        return comment;
+    }
+
     private int readValue(InputStream input, int length) throws IOException {
         int value = 0;
 

--- a/src/main/java/ghidrevm/evm/CborDecoder.java
+++ b/src/main/java/ghidrevm/evm/CborDecoder.java
@@ -1,0 +1,31 @@
+package ghidrevm.evm;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import ghidra.program.flatapi.FlatProgramAPI;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.StructureDataType;
+import ghidra.program.model.data.ByteDataType;
+import ghidra.program.model.data.DWordDataType;
+import ghidra.program.model.data.QWordDataType;
+import ghidra.program.model.data.UnsignedInteger3DataType;
+import ghidra.program.model.data.UnsignedInteger5DataType;
+import ghidra.program.model.data.UnsignedInteger6DataType;
+import ghidra.program.model.data.UnsignedInteger7DataType;
+import ghidra.program.model.data.UnsignedLongLongDataType;
+import ghidra.program.model.data.WordDataType;
+import ghidra.program.model.data.ArrayDataType;
+import ghidra.program.model.data.StringDataType;
+
+public class CborDecoder {
+    // Variable
+    private FlatProgramAPI api;
+    private int index;
+
+}

--- a/src/main/java/ghidrevm/evm/CborDecoder.java
+++ b/src/main/java/ghidrevm/evm/CborDecoder.java
@@ -10,18 +10,11 @@ import java.util.Map;
 import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.data.DataType;
-import ghidra.program.model.data.StructureDataType;
 import ghidra.program.model.data.ByteDataType;
 import ghidra.program.model.data.DWordDataType;
 import ghidra.program.model.data.QWordDataType;
-import ghidra.program.model.data.UnsignedInteger3DataType;
-import ghidra.program.model.data.UnsignedInteger5DataType;
-import ghidra.program.model.data.UnsignedInteger6DataType;
-import ghidra.program.model.data.UnsignedInteger7DataType;
-import ghidra.program.model.data.UnsignedLongLongDataType;
 import ghidra.program.model.data.WordDataType;
 import ghidra.program.model.data.ArrayDataType;
-import ghidra.program.model.data.StringDataType;
 
 public class CborDecoder {
     // Variable

--- a/src/main/java/ghidrevm/evm/CborDecoder.java
+++ b/src/main/java/ghidrevm/evm/CborDecoder.java
@@ -28,4 +28,90 @@ public class CborDecoder {
     private FlatProgramAPI api;
     private int index;
 
+    private int readValue(InputStream input, int length) throws IOException {
+        int value = 0;
+
+        for (int i = 0; i < length; i++) {
+            value = (value << 8) | input.read();
+        }
+
+        String comment = "Value(" + value + ")";
+        generateComment(comment, length, false);
+        return value;
+    }
+
+    private byte[] readByte(InputStream input, int length, boolean asString) throws IOException {
+        byte[] bytes = readData(input, length);
+        String comment = bytesConversion(bytes, asString);
+        generateComment(comment, length, asString);
+        return bytes;
+    }
+
+    private byte[] readData(InputStream input, int length) throws IOException {
+        byte[] bytes = new byte[length];
+        int bytesRead = input.read(bytes);
+        if (bytesRead != length) {
+            throw new IOException("Unexpected end of input");
+        }
+        return bytes;
+    }
+
+    private static String bytesConversion(byte[] data, boolean asString) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : data) {
+            if (asString)
+                hexString.append((char) b);
+            else
+                hexString.append(String.format("%02X", b & 0xFF));
+        }
+        return hexString.toString();
+    }
+
+    private List<Object> readArray(InputStream input, int length) throws IOException {
+        List<Object> array = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+            array.add(decode(input));
+        }
+        return array;
+    }
+
+    private Map<Object, Object> readMap(InputStream input, int length) throws IOException {
+        Map<Object, Object> map = new HashMap<>(length);
+        for (int i = 0; i < length; i++) {
+            Object key = decode(input);
+            Object value = decode(input);
+            map.put(key, value);
+        }
+        return map;
+    }
+
+    public static DataType getDataTypeForSize(int size) {
+        switch (size) {
+            case 1:
+                return new ByteDataType();
+            case 2:
+                return new WordDataType();
+            case 4:
+                return new DWordDataType();
+            case 8:
+                return new QWordDataType();
+            default:
+                return new ArrayDataType(new ByteDataType(), size, 1);
+        }
+    }
+
+    private void generateComment(String comment, int length, boolean asString) {
+        DataType type = getDataTypeForSize(length);
+        Address addr = api.toAddr(index);
+        try {
+            if (asString)
+                api.createAsciiString(addr, length);
+            else
+                api.createData(addr, type);
+            api.setEOLComment(addr, comment);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        this.index += length;
+    }
 }

--- a/src/main/java/ghidrevm/evm/MetadataObj.java
+++ b/src/main/java/ghidrevm/evm/MetadataObj.java
@@ -1,0 +1,91 @@
+package ghidrevm.evm;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+
+import org.bitcoinj.core.Base58;
+
+public class MetadataObj {
+	// Metadata Value
+	private byte[] deployedByteCode;
+	private byte[] metadataByteCode;
+	private int startIndex;
+
+	// Metadata Property
+	private String ipfs;
+	private String solcVersion;
+	private Boolean experimental;
+	private String bzzr0;
+	private String bzzr1;
+	private Map<String, Object> additionalFields;
+
+	public MetadataObj(byte[] _deployedByteCode) {
+		this.additionalFields = new HashMap<>();
+		deployedByteCode = _deployedByteCode;
+	}
+
+	public byte[] getDeployedByteCode() {
+		return deployedByteCode;
+	}
+
+	public byte[] getMetadataByteCode() {
+		return metadataByteCode;
+	}
+
+	public int getStartIndex() {
+		return startIndex;
+	}
+
+	public String getIpfs() {
+		return ipfs;
+	}
+
+	private void setIpfs(String ipfs) {
+		this.ipfs = ipfs;
+	}
+
+	public String getSolcVersion() {
+		return solcVersion;
+	}
+
+	private void setSolcVersion(String solcVersion) {
+		this.solcVersion = solcVersion;
+	}
+
+	public Boolean getExperimental() {
+		return experimental;
+	}
+
+	private void setExperimental(Boolean experimental) {
+		this.experimental = experimental;
+	}
+
+	public String getBzzr0() {
+		return bzzr0;
+	}
+
+	private void setBzzr0(String bzzr0) {
+		this.bzzr0 = bzzr0;
+	}
+
+	public String getBzzr1() {
+		return bzzr1;
+	}
+
+	private void setBzzr1(String bzzr1) {
+		this.bzzr1 = bzzr1;
+	}
+
+	public Map<String, Object> getAdditionalFields() {
+		return additionalFields;
+	}
+
+	private void setAdditionalField(String key, Object value) {
+		this.additionalFields.put(key, value);
+	}
+}

--- a/src/main/java/ghidrevm/evm/MetadataObj.java
+++ b/src/main/java/ghidrevm/evm/MetadataObj.java
@@ -29,6 +29,135 @@ public class MetadataObj {
 		deployedByteCode = _deployedByteCode;
 	}
 
+	public void decodeMetadata() throws IOException {
+		byte[] metadataByteCode = getMetadataByteCode(this.deployedByteCode);
+		if (metadataByteCode == null)
+			return;
+
+		JsonNode metadataJsonNode = decodeCborToJsonNode(metadataByteCode);
+
+		metadataJsonNode.fields().forEachRemaining(entry -> {
+			String fieldName = entry.getKey();
+			JsonNode fieldValue = entry.getValue();
+
+			switch (fieldName) {
+				case "solc":
+					String version = extractVersion(extractHexString(fieldValue, ""));
+					this.setSolcVersion(version);
+					break;
+				case "ipfs":
+					this.setIpfs(extractIpfsHash(fieldValue, ""));
+					break;
+				case "experimental":
+					this.setExperimental(fieldValue.asBoolean());
+					break;
+				case "bzzr0":
+					this.setBzzr0(extractHexString(fieldValue, ""));
+					break;
+				case "bzzr1":
+					this.setBzzr1(extractHexString(fieldValue, ""));
+					break;
+				default:
+					this.setAdditionalField(fieldName, extractHexString(fieldValue, null));
+					break;
+			}
+
+		});
+	}
+
+	private byte[] getMetadataByteCode(byte[] data) {
+		int bytesLength = 2;
+
+		// Can not decode metadata length
+		if (data.length < bytesLength)
+			return null;
+
+		int metadataLength = ((data[data.length - 2] & 0xFF) << 8) | (data[data.length - 1] & 0xFF);
+
+		// Metadata length not matched
+		if (data.length - bytesLength - metadataLength <= 0)
+			return null;
+
+		// Extract metadata section
+		byte[] metadata = new byte[metadataLength];
+		this.startIndex = data.length - metadataLength - 2;
+		System.arraycopy(data, data.length - metadataLength - 2, metadata, 0, metadata.length);
+
+		this.metadataByteCode = metadata;
+
+		return metadata;
+	}
+
+	private static JsonNode decodeCborToJsonNode(byte[] cborData) throws IOException {
+		CBORFactory cborFactory = new CBORFactory();
+		ObjectMapper cborMapper = new ObjectMapper(cborFactory);
+		return cborMapper.readTree(cborData);
+	}
+
+	private static String extractHexString(JsonNode data, String defaultValue) {
+		try {
+			return jsonNodeToHex(data);
+		} catch (IOException e) {
+			e.printStackTrace();
+			return defaultValue;
+		}
+	}
+
+	private static String extractVersion(String version) {
+		if (version.length() < 8)
+			return "";
+
+		version = version.substring(2);
+
+		String data = "";
+		int decimalString = 0;
+		decimalString = Integer.parseInt(version.substring(0, 2));
+		data += decimalString + ".";
+
+		decimalString = Integer.parseInt(version.substring(2, 4));
+		data += decimalString + ".";
+
+		decimalString = Integer.parseInt(version.substring(4, 6));
+		data += decimalString;
+
+		return data;
+	}
+
+	private static String extractIpfsHash(JsonNode fieldValue, String defaultValue) {
+		try {
+			byte[] _base58EncodedHash = jsonNodeToByte(fieldValue);
+			byte[] base58EncodedHash = new byte[_base58EncodedHash.length - 2];
+			System.arraycopy(_base58EncodedHash, 2, base58EncodedHash, 0, base58EncodedHash.length);
+			return Base58.encode(base58EncodedHash);
+		} catch (IOException e) {
+			e.printStackTrace();
+			return defaultValue;
+		}
+	}
+
+	private static String jsonNodeToHex(JsonNode jsonNode) throws IOException {
+		byte[] cborBytes = jsonNodeToByte(jsonNode);
+
+		// Convert byte array to hexadecimal string
+		StringBuilder hexString = new StringBuilder();
+		for (byte b : cborBytes) {
+			String hex = String.format("%02X", b & 0xFF); // Convert byte to unsigned hex string
+			hexString.append(hex);
+		}
+
+		return hexString.toString();
+	}
+
+	private static byte[] jsonNodeToByte(JsonNode jsonNode) throws IOException {
+		// Create a CBOR factory and object mapper
+		CBORFactory cborFactory = new CBORFactory();
+		ObjectMapper cborMapper = new ObjectMapper(cborFactory);
+
+		// Convert JsonNode to CBOR-encoded byte array
+		byte[] cborBytes = cborMapper.writeValueAsBytes(jsonNode);
+		return cborBytes;
+	}
+
 	public byte[] getDeployedByteCode() {
 		return deployedByteCode;
 	}


### PR DESCRIPTION
# Summary

Extract smart contract metadata and display the information after loading the program. Information including IPFS hash, compiler version, and more.

# Description
According to the solidity compiler [documentation](https://docs.soliditylang.org/en/latest/metadata.html) and the [article](https://www.rareskills.io/post/solidity-metadata) from Rareskills, the smart contract metadata is appended to the smart contract runtime code.

The metadata is encoded in `Cbor` format and there is no global protocol for metadata encoding. After Solidity 0.8.0 compiler version, the metadata section starts with an `INVALID` opcode (`FE`) but there is no such pattern in Solidity 0.6.0 and earlier version.

This PR follows the `ethereum-sourcify` - an ethereum open source tools for contract verificatioln, and the metadata is displayed at the import summary after loading the program.

# Verification

Randomly pick up two contract and extract the metadata through `Ghidrevm` and sourcify [playground](https://playground.sourcify.dev/), the result should be the same.

## Case 1: Metadata includes IPFS hash and Solidity compiler version (Common Case)

Address: `0x00000000219ab540356cBB839Cbe05303d7705Fa`

Result: 

```
{
  "ipfs": "0x1220dceca8706b29e917dacf25fceef95acac8d90d765ac926663ce4096195952b61",
  "solc": "0x00060b"
}
```

## Case 2: No IPFS hash

Address: `0xe592427a0aece92de3edee1f18e0157c05861564`

Result:

```
{
  "solc": "0x000706"
}
```

## Case 3: There is experimental flag and bzzr0, bzzr1 field

Address: `0x1F2c3a1046c32729862fcB038369696e3273a516 `

Result:
```
{
  "bzzr1": "0x7eea408e568f2b63599acab5435027c647d16c8da004a96930363835dfbc8f02",
  "experimental": true,
  "solc": "0x000510"
}
```

## Case 4: No metadata appended

Address: `0x9af09991ad63814e53ffc1bccf213ee74027608b`

### Other Cases

bzzr1 hash - `0xe9e7cea3dedca5984780bafc599bd69add087d56 `

bzzr0 hash - `0x78a9e536EBdA08b5b9EDbE5785C9D1D50fA3278C `