### PR TITLE
feat: add loading plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 	// https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformats-cbor
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.17.2'
 	implementation 'org.bitcoinj:bitcoinj-core:0.12'
+	implementation 'org.web3j:core:4.8.7'
 }
 
 // Exclude additional files from the built extension

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -91,15 +91,6 @@ public class GhidrevmPlugin extends Plugin
 
 	public GhidrevmPlugin(PluginTool tool) {
 		super(tool);
-
-		// TODO: Customize provider (or remove if a provider is not desired)
-		String pluginName = getName();
-		provider = new MyProvider(this, pluginName);
-
-		// TODO: Customize help (or remove if help is not desired)
-		String topicName = this.getClass().getPackage().getName();
-		String anchorName = "HelpAnchor";
-		provider.setHelpLocation(new HelpLocation(topicName, anchorName));
 	}
 
 	@Override
@@ -236,7 +227,20 @@ public class GhidrevmPlugin extends Plugin
 	    dialog.add(buttonPanel, BorderLayout.SOUTH);
 
 	    Map<String, String> rpcNodeLinks = setupRpcNodeLinks();
+
+	    loadByBytecodeButton.addActionListener(e -> {
+	        dialog.dispose();
+	        loadBytecode(fetchBytecodeOptionTextArea.getText(), filenameTextArea.getText());
+	    });
+
+	    loadByAddressButton.addActionListener(e -> {
+	        dialog.dispose();
+	        String selectedNetwork = (String) networkOptionsComboBox.getSelectedItem();
+	        String rpcEndpoint = rpcNodeLinks.getOrDefault(selectedNetwork, filenameTextArea.getText());
+	        fetchContractBytecode(rpcEndpoint, fetchBytecodeOptionTextArea.getText(), filenameTextArea.getText());
+	    });
 	}
+
 	private Map<String, String> setupRpcNodeLinks() {
 	    Map<String, String> rpcNodeLinks = new HashMap<>();
 	    rpcNodeLinks.put("Ethereum", "https://rpc.ankr.com/eth");
@@ -277,6 +281,7 @@ public class GhidrevmPlugin extends Plugin
 	private void showErrorPopup(String title, String message) {
 	    JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
 	}
+
 	private void loadBytecode(String bytecode, String filename) {
         // Clean and prepare the bytecode and filename
         String cleanedBytecode = removePrefix(bytecode, "0x");

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -79,15 +79,16 @@ import ghidra.util.task.TaskMonitor;
     eventsConsumed = { ProgramActivatedPluginEvent.class }
 )
 //@formatter:on
-public class GhidrevmPlugin extends ProgramPlugin {
+public class GhidrevmPlugin extends Plugin
+		implements ApplicationLevelPlugin, ProjectListener {
 
-	MyProvider provider;
+	private static final String SIMPLE_UNPACK_OPTION = "";
+	private static final boolean SIMPLE_UNPACK_OPTION_DEFAULT = false;
 
-	/**
-	 * Plugin constructor.
-	 * 
-	 * @param tool The plugin tool that this plugin is added to.
-	 */
+	private DockingAction downloadBytecodeAction;
+	private GhidraFileChooser chooser;
+	private FrontEndService frontEndService;
+
 	public GhidrevmPlugin(PluginTool tool) {
 		super(tool);
 
@@ -102,14 +103,22 @@ public class GhidrevmPlugin extends ProgramPlugin {
 	}
 
 	@Override
-	public void init() {
+	protected void init() {
 		super.init();
 
-		// TODO: Acquire services if necessary
-	}
+		frontEndService = tool.getService(FrontEndService.class);
+		if (frontEndService != null) {
+			frontEndService.addProjectListener(this);
+
+			ToolOptions options = tool.getOptions(ToolConstants.FILE_IMPORT_OPTIONS);
+			HelpLocation help = new HelpLocation("ImporterPlugin", "Project_Tree");
+
+			options.registerOption(SIMPLE_UNPACK_OPTION, SIMPLE_UNPACK_OPTION_DEFAULT, help,
+				"Perform simple unpack when any packed DB file is imported");
+		}
 
 	// TODO: If provider is desired, it is recommended to move it to its own file
-	private static class MyProvider extends ComponentProvider {
+	}
 
 		private JPanel panel;
 		private DockingAction action;

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -105,7 +105,7 @@ public class GhidrevmPlugin extends Plugin
 			HelpLocation help = new HelpLocation("ImporterPlugin", "Project_Tree");
 
 			options.registerOption(SIMPLE_UNPACK_OPTION, SIMPLE_UNPACK_OPTION_DEFAULT, help,
-				"Perform simple unpack when any packed DB file is imported");
+					"Perform simple unpack when any packed DB file is imported");
 		}
 
 		setupDownloadBytecodeAction();
@@ -115,7 +115,7 @@ public class GhidrevmPlugin extends Plugin
 	protected void dispose() {
 		super.dispose();
 		if (downloadBytecodeAction != null) {
-			downloadBytecodeAction.dispose(); 
+			downloadBytecodeAction.dispose();
 		}
 		if (frontEndService != null) {
 			frontEndService.removeProjectListener(this);
@@ -138,17 +138,17 @@ public class GhidrevmPlugin extends Plugin
 
 	private void setupDownloadBytecodeAction() {
 		downloadBytecodeAction = new DockingAction("Download ByteCode", getName()) {
-            @Override
-            public void actionPerformed(ActionContext context) {
-            	showDownloadBytecodeDialog();
-            }
-        };
-        downloadBytecodeAction.setMenuBarData(new MenuData(new String[] { "&File", "Download ByteCode" }, null,
-                "Import", MenuData.NO_MNEMONIC, "1"));
-        downloadBytecodeAction.setKeyBindingData(null);
-        downloadBytecodeAction.setEnabled(true);
-        downloadBytecodeAction.markHelpUnnecessary();
-        tool.addAction(downloadBytecodeAction);
+			@Override
+			public void actionPerformed(ActionContext context) {
+				showDownloadBytecodeDialog();
+			}
+		};
+		downloadBytecodeAction.setMenuBarData(new MenuData(new String[] { "&File", "Download ByteCode" }, null,
+				"Import", MenuData.NO_MNEMONIC, "1"));
+		downloadBytecodeAction.setKeyBindingData(null);
+		downloadBytecodeAction.setEnabled(true);
+		downloadBytecodeAction.markHelpUnnecessary();
+		tool.addAction(downloadBytecodeAction);
 	}
 
 	@Override
@@ -160,182 +160,186 @@ public class GhidrevmPlugin extends Plugin
 	public void projectOpened(Project project) {
 		// No-ops
 	}
-	
+
 	private void showDownloadBytecodeDialog() {
-	    JDialog dialog = createDialog("Download ByteCode");
+		JDialog dialog = createDialog("Download ByteCode");
 
-	    // Create the necessary input components
-	    JComboBox<String> networkOptionsComboBox = createNetworkOptionsComboBox();
-	    JTextArea filenameTextArea = createTextArea(1, 5);
-	    JTextArea fetchBytecodeOptionTextArea = createTextArea(20, 50);
+		// Create the necessary input components
+		JComboBox<String> networkOptionsComboBox = createNetworkOptionsComboBox();
+		JTextArea filenameTextArea = createTextArea(1, 5);
+		JTextArea fetchBytecodeOptionTextArea = createTextArea(20, 50);
 
-	    // Set up the main content
-	    setupMainContent(dialog, networkOptionsComboBox, filenameTextArea, fetchBytecodeOptionTextArea);
+		// Set up the main content
+		setupMainContent(dialog, networkOptionsComboBox, filenameTextArea, fetchBytecodeOptionTextArea);
 
-	    // Set up the buttons and their actions
-	    setupButtonsAndActions(dialog, networkOptionsComboBox, filenameTextArea, fetchBytecodeOptionTextArea);
+		// Set up the buttons and their actions
+		setupButtonsAndActions(dialog, networkOptionsComboBox, filenameTextArea, fetchBytecodeOptionTextArea);
 
-	    // Finalize the dialog setup
-	    finalizeDialog(dialog);
+		// Finalize the dialog setup
+		finalizeDialog(dialog);
 	}
 
 	private JDialog createDialog(String title) {
-	    JDialog dialog = new JDialog(tool.getToolFrame(), title, true);
-	    dialog.setLayout(new BorderLayout());
-	    return dialog;
+		JDialog dialog = new JDialog(tool.getToolFrame(), title, true);
+		dialog.setLayout(new BorderLayout());
+		return dialog;
 	}
 
 	private JComboBox<String> createNetworkOptionsComboBox() {
-	    String[] networkOptions = {"Ethereum", "Polygon", "Arbitrum", "Optimism", "More"};
-	    JComboBox<String> comboBox = new JComboBox<>(networkOptions);
-	    comboBox.setEditable(true);
-	    return comboBox;
+		String[] networkOptions = { "Ethereum", "Polygon", "Arbitrum", "Optimism", "More" };
+		JComboBox<String> comboBox = new JComboBox<>(networkOptions);
+		comboBox.setEditable(true);
+		return comboBox;
 	}
 
 	private JTextArea createTextArea(int rows, int columns) {
-	    JTextArea textArea = new JTextArea(rows, columns);
-	    textArea.setWrapStyleWord(true);
-	    textArea.setLineWrap(true);
-	    return textArea;
+		JTextArea textArea = new JTextArea(rows, columns);
+		textArea.setWrapStyleWord(true);
+		textArea.setLineWrap(true);
+		return textArea;
 	}
 
-	private void setupMainContent(JDialog dialog, JComboBox<String> networkOptionsComboBox, JTextArea filenameTextArea, JTextArea fetchBytecodeOptionTextArea) {
-	    JPanel mainPanel = new JPanel(new BorderLayout());
+	private void setupMainContent(JDialog dialog, JComboBox<String> networkOptionsComboBox, JTextArea filenameTextArea,
+			JTextArea fetchBytecodeOptionTextArea) {
+		JPanel mainPanel = new JPanel(new BorderLayout());
 
-	    mainPanel.add(createPanel("Network", networkOptionsComboBox), BorderLayout.NORTH);
-	    mainPanel.add(createPanel("File Name", new JScrollPane(filenameTextArea)), BorderLayout.CENTER);
-	    mainPanel.add(createPanel("Deployed Bytecode / Contract Address", new JScrollPane(fetchBytecodeOptionTextArea)), BorderLayout.SOUTH);
+		mainPanel.add(createPanel("Network", networkOptionsComboBox), BorderLayout.NORTH);
+		mainPanel.add(createPanel("File Name", new JScrollPane(filenameTextArea)), BorderLayout.CENTER);
+		mainPanel.add(createPanel("Deployed Bytecode / Contract Address", new JScrollPane(fetchBytecodeOptionTextArea)),
+				BorderLayout.SOUTH);
 
-	    dialog.add(mainPanel, BorderLayout.CENTER);
+		dialog.add(mainPanel, BorderLayout.CENTER);
 	}
 
 	private JPanel createPanel(String labelText, JComponent component) {
-	    JPanel panel = new JPanel(new BorderLayout());
-	    JLabel label = new JLabel(labelText);
-	    panel.add(label, BorderLayout.NORTH);
-	    panel.add(component, BorderLayout.CENTER);
-	    return panel;
+		JPanel panel = new JPanel(new BorderLayout());
+		JLabel label = new JLabel(labelText);
+		panel.add(label, BorderLayout.NORTH);
+		panel.add(component, BorderLayout.CENTER);
+		return panel;
 	}
 
-	private void setupButtonsAndActions(JDialog dialog, JComboBox<String> networkOptionsComboBox, JTextArea filenameTextArea, JTextArea fetchBytecodeOptionTextArea) {
-	    JPanel buttonPanel = new JPanel(new GridLayout(1, 2));
-	    JButton loadByBytecodeButton = new JButton("By Bytecode");
-	    JButton loadByAddressButton = new JButton("By Address");
+	private void setupButtonsAndActions(JDialog dialog, JComboBox<String> networkOptionsComboBox,
+			JTextArea filenameTextArea, JTextArea fetchBytecodeOptionTextArea) {
+		JPanel buttonPanel = new JPanel(new GridLayout(1, 2));
+		JButton loadByBytecodeButton = new JButton("By Bytecode");
+		JButton loadByAddressButton = new JButton("By Address");
 
-	    buttonPanel.add(loadByBytecodeButton);
-	    buttonPanel.add(loadByAddressButton);
-	    dialog.add(buttonPanel, BorderLayout.SOUTH);
+		buttonPanel.add(loadByBytecodeButton);
+		buttonPanel.add(loadByAddressButton);
+		dialog.add(buttonPanel, BorderLayout.SOUTH);
 
-	    Map<String, String> rpcNodeLinks = setupRpcNodeLinks();
+		Map<String, String> rpcNodeLinks = setupRpcNodeLinks();
 
-	    loadByBytecodeButton.addActionListener(e -> {
-	        dialog.dispose();
-	        loadBytecode(fetchBytecodeOptionTextArea.getText(), filenameTextArea.getText());
-	    });
+		loadByBytecodeButton.addActionListener(e -> {
+			dialog.dispose();
+			loadBytecode(fetchBytecodeOptionTextArea.getText(), filenameTextArea.getText());
+		});
 
-	    loadByAddressButton.addActionListener(e -> {
-	        dialog.dispose();
-	        String selectedNetwork = (String) networkOptionsComboBox.getSelectedItem();
-	        String rpcEndpoint = rpcNodeLinks.getOrDefault(selectedNetwork, filenameTextArea.getText());
-	        fetchContractBytecode(rpcEndpoint, fetchBytecodeOptionTextArea.getText(), filenameTextArea.getText());
-	    });
+		loadByAddressButton.addActionListener(e -> {
+			dialog.dispose();
+			String selectedNetwork = (String) networkOptionsComboBox.getSelectedItem();
+			String rpcEndpoint = rpcNodeLinks.getOrDefault(selectedNetwork, filenameTextArea.getText());
+			fetchContractBytecode(rpcEndpoint, fetchBytecodeOptionTextArea.getText(), filenameTextArea.getText());
+		});
 	}
 
 	private Map<String, String> setupRpcNodeLinks() {
-	    Map<String, String> rpcNodeLinks = new HashMap<>();
-	    rpcNodeLinks.put("Ethereum", "https://rpc.ankr.com/eth");
-	    rpcNodeLinks.put("Polygon", "https://rpc.ankr.com/polygon");
-	    rpcNodeLinks.put("Arbitrum", "https://rpc.ankr.com/arbitrum");
-	    rpcNodeLinks.put("Optimism", "https://rpc.ankr.com/optimism");
-	    return rpcNodeLinks;
+		Map<String, String> rpcNodeLinks = new HashMap<>();
+		rpcNodeLinks.put("Ethereum", "https://rpc.ankr.com/eth");
+		rpcNodeLinks.put("Polygon", "https://rpc.ankr.com/polygon");
+		rpcNodeLinks.put("Arbitrum", "https://rpc.ankr.com/arbitrum");
+		rpcNodeLinks.put("Optimism", "https://rpc.ankr.com/optimism");
+		return rpcNodeLinks;
 	}
 
 	private void finalizeDialog(JDialog dialog) {
-	    dialog.pack();
-	    dialog.setLocationRelativeTo(tool.getToolFrame());
-	    dialog.setVisible(true);
+		dialog.pack();
+		dialog.setLocationRelativeTo(tool.getToolFrame());
+		dialog.setVisible(true);
 	}
-	
+
 	private void fetchContractBytecode(String rpcEndpoint, String contractAddress, String filename) {
 		// Set up the web3j service
 		String errorTitle = "Failed to fetch bytecode";
 		String errorMessage = "The fetched bytecode is null or empty. Please check the contract address and try again.";
-        Web3j web3j = Web3j.build(new HttpService(rpcEndpoint));
+		Web3j web3j = Web3j.build(new HttpService(rpcEndpoint));
 
-        try {
-        	// Fetch the contract bytecode.
-            EthGetCode ethGetCode = web3j.ethGetCode(contractAddress, DefaultBlockParameterName.LATEST).send();
-            String bytecode = ethGetCode.getCode();
-            
-            if (bytecode == null || bytecode.isEmpty())
-                showErrorPopup(errorTitle, errorMessage);
-            else
-                loadBytecode(bytecode, filename);
+		try {
+			// Fetch the contract bytecode.
+			EthGetCode ethGetCode = web3j.ethGetCode(contractAddress, DefaultBlockParameterName.LATEST).send();
+			String bytecode = ethGetCode.getCode();
 
-        } catch (IOException e) {
-            e.printStackTrace();
-            showErrorPopup(errorTitle, errorMessage);
-        }
-    }
-	
+			if (bytecode == null || bytecode.isEmpty())
+				showErrorPopup(errorTitle, errorMessage);
+			else
+				loadBytecode(bytecode, filename);
+
+		} catch (IOException e) {
+			e.printStackTrace();
+			showErrorPopup(errorTitle, errorMessage);
+		}
+	}
+
 	private void showErrorPopup(String title, String message) {
-	    JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
+		JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
 	}
 
 	private void loadBytecode(String bytecode, String filename) {
-        // Clean and prepare the bytecode and filename
-        String cleanedBytecode = removePrefix(bytecode, "0x");
-        String fullFilename = appendSuffix(filename, ".evm");
-	    try {
-	        // Set up the loader and load specification
-	        GhidrevmLoader loader = new GhidrevmLoader();
-	        LoadSpec loadSpec = configureLoadSpec(loader, "evm:256:default", "default");
+		// Clean and prepare the bytecode and filename
+		String cleanedBytecode = removePrefix(bytecode, "0x");
+		String fullFilename = appendSuffix(filename, ".evm");
+		try {
+			// Set up the loader and load specification
+			GhidrevmLoader loader = new GhidrevmLoader();
+			LoadSpec loadSpec = configureLoadSpec(loader, "evm:256:default", "default");
 
-	        // Load the bytecode using the custom loader
-	        loadAndSaveBytecode(cleanedBytecode, fullFilename, loadSpec);
-	    } catch (Exception e) {
-	        e.printStackTrace();
-	    }
+			// Load the bytecode using the custom loader
+			loadAndSaveBytecode(cleanedBytecode, fullFilename, loadSpec);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 	private String removePrefix(String input, String prefix) {
-	    return input.startsWith(prefix) ? input.substring(prefix.length()) : input;
+		return input.startsWith(prefix) ? input.substring(prefix.length()) : input;
 	}
 
 	private String appendSuffix(String input, String suffix) {
-	    return input.endsWith(suffix) ? input : input + suffix;
+		return input.endsWith(suffix) ? input : input + suffix;
 	}
 
 	private LoadSpec configureLoadSpec(GhidrevmLoader loader, String languageSpec, String compilerSpecId) {
-	    LanguageCompilerSpecPair compilerSpec = new LanguageCompilerSpecPair(languageSpec, compilerSpecId);
-	    return new LoadSpec(loader, 0, compilerSpec, true);
+		LanguageCompilerSpecPair compilerSpec = new LanguageCompilerSpecPair(languageSpec, compilerSpecId);
+		return new LoadSpec(loader, 0, compilerSpec, true);
 	}
 
 	private void loadAndSaveBytecode(String bytecode, String filename, LoadSpec loadSpec) throws Exception {
-	    ByteProvider provider = new ByteArrayProvider(hexStringToByteArray(bytecode));
-	    Project project = AppInfo.getActiveProject();
-	    Object consumer = new Object();
-	    TaskMonitor monitor = new ConsoleTaskMonitor();
+		ByteProvider provider = new ByteArrayProvider(hexStringToByteArray(bytecode));
+		Project project = AppInfo.getActiveProject();
+		Object consumer = new Object();
+		TaskMonitor monitor = new ConsoleTaskMonitor();
 
-	    LoadResults<? extends DomainObject> results = loadSpec.getLoader().load(provider, filename, project, "", loadSpec, new ArrayList<>(), new MessageLog(), consumer, monitor);
+		LoadResults<? extends DomainObject> results = loadSpec.getLoader().load(provider, filename, project, "",
+				loadSpec, new ArrayList<>(), new MessageLog(), consumer, monitor);
 
-	    // Save the loading results to the project
-	    results.save(project, consumer, null, monitor);
+		// Save the loading results to the project
+		results.save(project, consumer, null, monitor);
 	}
-	
+
 	private byte[] hexStringToByteArray(String hexString) {
-	    Pattern p = Pattern.compile("[0-9a-fA-F]{2}");
-	    Matcher m = p.matcher(hexString);
+		Pattern p = Pattern.compile("[0-9a-fA-F]{2}");
+		Matcher m = p.matcher(hexString);
 
-	    int count = (int) m.results().count();
-	    m.reset();
+		int count = (int) m.results().count();
+		m.reset();
 
-	    byte[] byteCode = new byte[count];
-	    int i = 0;
-	    while (m.find()) {
-	        String hexDigit = m.group();
-	        byteCode[i++] = (byte) Integer.parseInt(hexDigit, 16);
-	    }
-	    return byteCode;
+		byte[] byteCode = new byte[count];
+		int i = 0;
+		while (m.find()) {
+			String hexDigit = m.group();
+			byteCode[i++] = (byte) Integer.parseInt(hexDigit, 16);
+		}
+		return byteCode;
 	}
 }

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -251,6 +251,32 @@ public class GhidrevmPlugin extends Plugin
 	    dialog.setLocationRelativeTo(tool.getToolFrame());
 	    dialog.setVisible(true);
 	}
+	
+	private void fetchContractBytecode(String rpcEndpoint, String contractAddress, String filename) {
+		// Set up the web3j service
+		String errorTitle = "Failed to fetch bytecode";
+		String errorMessage = "The fetched bytecode is null or empty. Please check the contract address and try again.";
+        Web3j web3j = Web3j.build(new HttpService(rpcEndpoint));
+
+        try {
+        	// Fetch the contract bytecode.
+            EthGetCode ethGetCode = web3j.ethGetCode(contractAddress, DefaultBlockParameterName.LATEST).send();
+            String bytecode = ethGetCode.getCode();
+            
+            if (bytecode == null || bytecode.isEmpty())
+                showErrorPopup(errorTitle, errorMessage);
+            else
+                loadBytecode(bytecode, filename);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            showErrorPopup(errorTitle, errorMessage);
+        }
+    }
+	
+	private void showErrorPopup(String title, String message) {
+	    JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
+	}
 	private void loadBytecode(String bytecode, String filename) {
         // Clean and prepare the bytecode and filename
         String cleanedBytecode = removePrefix(bytecode, "0x");

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -120,23 +120,30 @@ public class GhidrevmPlugin extends Plugin
 	// TODO: If provider is desired, it is recommended to move it to its own file
 	}
 
-		private JPanel panel;
-		private DockingAction action;
-
-		public MyProvider(Plugin plugin, String owner) {
-			super(plugin.getTool(), owner, owner);
-			buildPanel();
-			createActions();
+	@Override
+	protected void dispose() {
+		super.dispose();
+		if (downloadBytecodeAction != null) {
+			downloadBytecodeAction.dispose(); 
+		}
+		if (frontEndService != null) {
+			frontEndService.removeProjectListener(this);
+			frontEndService = null;
 		}
 
-		// Customize GUI
-		private void buildPanel() {
-			panel = new JPanel(new BorderLayout());
-			JTextArea textArea = new JTextArea(5, 25);
-			textArea.setEditable(false);
-			panel.add(new JScrollPane(textArea));
-			setVisible(true);
+		if (chooser != null) {
+			chooser.dispose();
 		}
+	}
+
+	@Override
+	public void processEvent(PluginEvent event) {
+		super.processEvent(event);
+
+		if (event instanceof ProgramActivatedPluginEvent) {
+			ProgramActivatedPluginEvent pape = (ProgramActivatedPluginEvent) event;
+		}
+	}
 
 		// TODO: Customize actions
 		private void createActions() {
@@ -152,9 +159,14 @@ public class GhidrevmPlugin extends Plugin
 			dockingTool.addLocalAction(this, action);
 		}
 
-		@Override
-		public JComponent getComponent() {
-			return panel;
-		}
+	@Override
+	public void projectClosed(Project project) {
+		// No-ops
+	}
+
+	@Override
+	public void projectOpened(Project project) {
+		// No-ops
+	}
 	}
 }

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -16,25 +16,59 @@
 package ghidrevm;
 
 import java.awt.BorderLayout;
+import java.awt.GridLayout;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.response.EthGetCode;
+import org.web3j.protocol.http.HttpService;
 
 import docking.ActionContext;
-import docking.ComponentProvider;
 import docking.action.DockingAction;
-import docking.action.ToolBarData;
-import ghidra.app.ExamplesPluginPackage;
+import docking.action.MenuData;
+import docking.tool.ToolConstants;
+import docking.widgets.filechooser.GhidraFileChooser;
+import ghidra.app.CorePluginPackage;
+import ghidra.app.events.ProgramActivatedPluginEvent;
 import ghidra.app.plugin.PluginCategoryNames;
-import ghidra.app.plugin.ProgramPlugin;
-import ghidra.framework.plugintool.*;
+import ghidra.app.util.bin.ByteArrayProvider;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.app.util.opinion.LoadResults;
+import ghidra.app.util.opinion.LoadSpec;
+import ghidra.framework.main.AppInfo;
+import ghidra.framework.main.ApplicationLevelPlugin;
+import ghidra.framework.main.FrontEndService;
+import ghidra.framework.model.DomainObject;
+import ghidra.framework.model.Project;
+import ghidra.framework.model.ProjectListener;
+import ghidra.framework.options.ToolOptions;
+import ghidra.framework.plugintool.Plugin;
+import ghidra.framework.plugintool.PluginEvent;
+import ghidra.framework.plugintool.PluginInfo;
+import ghidra.framework.plugintool.PluginTool;
 import ghidra.framework.plugintool.util.PluginStatus;
+import ghidra.program.model.lang.LanguageCompilerSpecPair;
 import ghidra.util.HelpLocation;
-import ghidra.util.Msg;
-import resources.Icons;
+import ghidra.util.task.ConsoleTaskMonitor;
+import ghidra.util.task.TaskMonitor;
 
-/**
- * TODO: Provide class-level documentation that describes what this plugin does.
- */
 //@formatter:off
 @PluginInfo(
 	status = PluginStatus.STABLE,

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -235,7 +235,15 @@ public class GhidrevmPlugin extends Plugin
 	    buttonPanel.add(loadByAddressButton);
 	    dialog.add(buttonPanel, BorderLayout.SOUTH);
 
+	    Map<String, String> rpcNodeLinks = setupRpcNodeLinks();
 	}
+	private Map<String, String> setupRpcNodeLinks() {
+	    Map<String, String> rpcNodeLinks = new HashMap<>();
+	    rpcNodeLinks.put("Ethereum", "https://rpc.ankr.com/eth");
+	    rpcNodeLinks.put("Polygon", "https://rpc.ankr.com/polygon");
+	    rpcNodeLinks.put("Arbitrum", "https://rpc.ankr.com/arbitrum");
+	    rpcNodeLinks.put("Optimism", "https://rpc.ankr.com/optimism");
+	    return rpcNodeLinks;
 	}
 
 	private void finalizeDialog(JDialog dialog) {

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -71,11 +71,12 @@ import ghidra.util.task.TaskMonitor;
 
 //@formatter:off
 @PluginInfo(
-	status = PluginStatus.STABLE,
-	packageName = ExamplesPluginPackage.NAME,
-	category = PluginCategoryNames.EXAMPLES,
-	shortDescription = "Plugin short description goes here.",
-	description = "Plugin long description goes here."
+    status = PluginStatus.RELEASED,
+    packageName = CorePluginPackage.NAME,
+    category = PluginCategoryNames.COMMON,
+    shortDescription = "Import External Files Through Address or Bytecode",
+    description = "This plugin allows the import of external files into the project, providing extended functionality for handling different types of data.",
+    eventsConsumed = { ProgramActivatedPluginEvent.class }
 )
 //@formatter:on
 public class GhidrevmPlugin extends ProgramPlugin {

--- a/src/main/java/ghidrevm/GhidrevmPlugin.java
+++ b/src/main/java/ghidrevm/GhidrevmPlugin.java
@@ -117,7 +117,7 @@ public class GhidrevmPlugin extends Plugin
 				"Perform simple unpack when any packed DB file is imported");
 		}
 
-	// TODO: If provider is desired, it is recommended to move it to its own file
+		setupDownloadBytecodeAction();
 	}
 
 	@Override
@@ -145,19 +145,20 @@ public class GhidrevmPlugin extends Plugin
 		}
 	}
 
-		// TODO: Customize actions
-		private void createActions() {
-			action = new DockingAction("My Action", getName()) {
-				@Override
-				public void actionPerformed(ActionContext context) {
-					Msg.showInfo(getClass(), panel, "Custom Action", "Hello!");
-				}
-			};
-			action.setToolBarData(new ToolBarData(Icons.ADD_ICON, null));
-			action.setEnabled(true);
-			action.markHelpUnnecessary();
-			dockingTool.addLocalAction(this, action);
-		}
+	private void setupDownloadBytecodeAction() {
+		downloadBytecodeAction = new DockingAction("Download ByteCode", getName()) {
+            @Override
+            public void actionPerformed(ActionContext context) {
+            	showDownloadBytecodeDialog();
+            }
+        };
+        downloadBytecodeAction.setMenuBarData(new MenuData(new String[] { "&File", "Download ByteCode" }, null,
+                "Import", MenuData.NO_MNEMONIC, "1"));
+        downloadBytecodeAction.setKeyBindingData(null);
+        downloadBytecodeAction.setEnabled(true);
+        downloadBytecodeAction.markHelpUnnecessary();
+        tool.addAction(downloadBytecodeAction);
+	}
 
 	@Override
 	public void projectClosed(Project project) {
@@ -167,6 +168,80 @@ public class GhidrevmPlugin extends Plugin
 	@Override
 	public void projectOpened(Project project) {
 		// No-ops
+	}
+	
+	private void showDownloadBytecodeDialog() {
+	    JDialog dialog = createDialog("Download ByteCode");
+
+	    // Create the necessary input components
+	    JComboBox<String> networkOptionsComboBox = createNetworkOptionsComboBox();
+	    JTextArea filenameTextArea = createTextArea(1, 5);
+	    JTextArea fetchBytecodeOptionTextArea = createTextArea(20, 50);
+
+	    // Set up the main content
+	    setupMainContent(dialog, networkOptionsComboBox, filenameTextArea, fetchBytecodeOptionTextArea);
+
+	    // Set up the buttons and their actions
+	    setupButtonsAndActions(dialog, networkOptionsComboBox, filenameTextArea, fetchBytecodeOptionTextArea);
+
+	    // Finalize the dialog setup
+	    finalizeDialog(dialog);
+	}
+
+	private JDialog createDialog(String title) {
+	    JDialog dialog = new JDialog(tool.getToolFrame(), title, true);
+	    dialog.setLayout(new BorderLayout());
+	    return dialog;
+	}
+
+	private JComboBox<String> createNetworkOptionsComboBox() {
+	    String[] networkOptions = {"Ethereum", "Polygon", "Arbitrum", "Optimism", "More"};
+	    JComboBox<String> comboBox = new JComboBox<>(networkOptions);
+	    comboBox.setEditable(true);
+	    return comboBox;
+	}
+
+	private JTextArea createTextArea(int rows, int columns) {
+	    JTextArea textArea = new JTextArea(rows, columns);
+	    textArea.setWrapStyleWord(true);
+	    textArea.setLineWrap(true);
+	    return textArea;
+	}
+
+	private void setupMainContent(JDialog dialog, JComboBox<String> networkOptionsComboBox, JTextArea filenameTextArea, JTextArea fetchBytecodeOptionTextArea) {
+	    JPanel mainPanel = new JPanel(new BorderLayout());
+
+	    mainPanel.add(createPanel("Network", networkOptionsComboBox), BorderLayout.NORTH);
+	    mainPanel.add(createPanel("File Name", new JScrollPane(filenameTextArea)), BorderLayout.CENTER);
+	    mainPanel.add(createPanel("Deployed Bytecode / Contract Address", new JScrollPane(fetchBytecodeOptionTextArea)), BorderLayout.SOUTH);
+
+	    dialog.add(mainPanel, BorderLayout.CENTER);
+	}
+
+	private JPanel createPanel(String labelText, JComponent component) {
+	    JPanel panel = new JPanel(new BorderLayout());
+	    JLabel label = new JLabel(labelText);
+	    panel.add(label, BorderLayout.NORTH);
+	    panel.add(component, BorderLayout.CENTER);
+	    return panel;
+	}
+
+	private void setupButtonsAndActions(JDialog dialog, JComboBox<String> networkOptionsComboBox, JTextArea filenameTextArea, JTextArea fetchBytecodeOptionTextArea) {
+	    JPanel buttonPanel = new JPanel(new GridLayout(1, 2));
+	    JButton loadByBytecodeButton = new JButton("By Bytecode");
+	    JButton loadByAddressButton = new JButton("By Address");
+
+	    buttonPanel.add(loadByBytecodeButton);
+	    buttonPanel.add(loadByAddressButton);
+	    dialog.add(buttonPanel, BorderLayout.SOUTH);
+
+	}
+	}
+
+	private void finalizeDialog(JDialog dialog) {
+	    dialog.pack();
+	    dialog.setLocationRelativeTo(tool.getToolFrame());
+	    dialog.setVisible(true);
 	}
 	}
 }

--- a/src/main/java/ghidrevm/evm/CborDecoder.java
+++ b/src/main/java/ghidrevm/evm/CborDecoder.java
@@ -23,10 +23,10 @@ public class CborDecoder {
 
     public CborDecoder(FlatProgramAPI api, int index, byte[] data) throws IOException {
         // Environment Configuration
-	   if (data == null) {
-           throw new IllegalArgumentException("The byte array 'data' cannot be null");
-       }
-    	
+        if (data == null) {
+            throw new IllegalArgumentException("The byte array 'data' cannot be null");
+        }
+
         this.api = api;
         this.index = index;
         Address addr = api.toAddr(index);

--- a/src/main/java/ghidrevm/evm/CborDecoder.java
+++ b/src/main/java/ghidrevm/evm/CborDecoder.java
@@ -23,6 +23,10 @@ public class CborDecoder {
 
     public CborDecoder(FlatProgramAPI api, int index, byte[] data) throws IOException {
         // Environment Configuration
+	   if (data == null) {
+           throw new IllegalArgumentException("The byte array 'data' cannot be null");
+       }
+    	
         this.api = api;
         this.index = index;
         Address addr = api.toAddr(index);
@@ -31,7 +35,7 @@ public class CborDecoder {
         // Metadata Decoding
         ByteArrayInputStream input = new ByteArrayInputStream(data);
         while (input.available() > 0) {
-            System.out.println(decode(input));
+            decode(input);
         }
     }
 

--- a/src/main/java/ghidrevm/evm/MetadataObj.java
+++ b/src/main/java/ghidrevm/evm/MetadataObj.java
@@ -104,23 +104,24 @@ public class MetadataObj {
 	}
 
 	private static String extractVersion(String version) {
-		if (version.length() < 8)
-			return "";
+	    if (version.length() < 8) {
+	        return "";
+	    }
 
-		version = version.substring(2);
+	    version = version.substring(2);
 
-		String data = "";
-		int decimalString = 0;
-		decimalString = Integer.parseInt(version.substring(0, 2));
-		data += decimalString + ".";
+	    StringBuilder data = new StringBuilder();
 
-		decimalString = Integer.parseInt(version.substring(2, 4));
-		data += decimalString + ".";
+	    int decimalValue = Integer.parseInt(version.substring(0, 2), 16);
+	    data.append(decimalValue).append(".");
 
-		decimalString = Integer.parseInt(version.substring(4, 6));
-		data += decimalString;
+	    decimalValue = Integer.parseInt(version.substring(2, 4), 16);
+	    data.append(decimalValue).append(".");
 
-		return data;
+	    decimalValue = Integer.parseInt(version.substring(4, 6), 16);
+	    data.append(decimalValue);
+
+	    return data.toString();
 	}
 
 	private static String extractIpfsHash(JsonNode fieldValue, String defaultValue) {

--- a/src/main/java/ghidrevm/evm/MetadataObj.java
+++ b/src/main/java/ghidrevm/evm/MetadataObj.java
@@ -104,24 +104,24 @@ public class MetadataObj {
 	}
 
 	private static String extractVersion(String version) {
-	    if (version.length() < 8) {
-	        return "";
-	    }
+		if (version.length() < 8) {
+			return "";
+		}
 
-	    version = version.substring(2);
+		version = version.substring(2);
 
-	    StringBuilder data = new StringBuilder();
+		StringBuilder data = new StringBuilder();
 
-	    int decimalValue = Integer.parseInt(version.substring(0, 2), 16);
-	    data.append(decimalValue).append(".");
+		int decimalValue = Integer.parseInt(version.substring(0, 2), 16);
+		data.append(decimalValue).append(".");
 
-	    decimalValue = Integer.parseInt(version.substring(2, 4), 16);
-	    data.append(decimalValue).append(".");
+		decimalValue = Integer.parseInt(version.substring(2, 4), 16);
+		data.append(decimalValue).append(".");
 
-	    decimalValue = Integer.parseInt(version.substring(4, 6), 16);
-	    data.append(decimalValue);
+		decimalValue = Integer.parseInt(version.substring(4, 6), 16);
+		data.append(decimalValue);
 
-	    return data.toString();
+		return data.toString();
 	}
 
 	private static String extractIpfsHash(JsonNode fieldValue, String defaultValue) {


### PR DESCRIPTION
# Summary

Previously, users could only load bytecode by importing a file, which required several steps: finding the bytecode using the contract address on block explorer, downloading it, and then importing the file. This feature allows users to directly download the bytecode given the contract address, with the plugin automatically downloading and saving it.

# Introduction

In this plugin, users can provide either the contract address or the contract bytecode, and user do not need to save them as a file in advance. If the contract address is provided, the user must also specify the preferred filename and blockchain network. The plugin will then fetch the code from the RPC node, download it, and save the result. If the bytecode and the filename are provided, the plugin will automatically save it. Users can later analyze the code by selecting it.

# Verification 

## Case 1
Chain: Ethereum Mainnet
Address: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2

## Case 2
Chain: Arbitrum
Address: 0xA0dF47432d9d88bcc040E9ee66dDC7E17A882715

## Case 3
Chain: Polygon
Address: 0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619

## Case 4
Chain: Optimism
Address: 0x98d69620C31869fD4822ceb6ADAB31180475FD37